### PR TITLE
multiple enhancements to enable deploy exhibitor-appliance within different teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,6 @@ Runs an [Exhibitor](https://github.com/Netflix/exhibitor)-managed [ZooKeeper](ht
 docker build -t <tag> .
 ```
 
-###### Create the Security group
-```
-GROUP_ID=$(aws ec2 create-security-group --group-name app-exhibitor --description "Exhibitor security group" \
-  | sed -rn 's/.*GroupId": "(.*)".*/\1/p' | tail -n 1)
-aws ec2 authorize-security-group-ingress --group-id $GROUP_ID --protocol tcp --port 22 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id $GROUP_ID --protocol tcp --port 80 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id $GROUP_ID --protocol tcp --port 2181 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id $GROUP_ID --protocol tcp --port 2888 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id $GROUP_ID --protocol tcp --port 3888 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id $GROUP_ID --protocol tcp --port 8181 --cidr 0.0.0.0/0
-```
-
 ###### Create S3 bucket
 ```
 S3_BUCKET="exhibitor-app"
@@ -28,11 +16,18 @@ aws s3 mb s3://$S3_BUCKET
 ###### Register appliance in YourTourn
 Docs: http://docs.stups.io/en/latest/components/yourturn.html
 
+Make sure that your got an unique ```APPLICATION_ID```
+
 ###### Deploy with Senza
 ```
-senza create exhibitor-appliance.yaml <STACK_VERSION> <DOCKER_IMAGE> $GROUP_ID <HOSTED_ZONE> $S3_BUCKET <MINT_BUCKET> <SCALYR_KEY>
+senza create exhibitor-appliance.yaml <STACK_VERSION> <APPLICATION_ID> <DOCKER_IMAGE_WITH_VERSION_TAG> <HOSTED_ZONE> $S3_BUCKET <MINT_BUCKET> <SCALYR_KEY> [--region AWS_REGION]
 ```
 
-Cloudformation stack will start 3 EC2 instances in autoscaling group and create internal load balancer in front of EC2 instances. Also it will create DNS record ```"<STACK_VERSION>.exhibitor.<HOSTED_ZONE>"``` which points to a load balancer.
+A real world example would be:
+```
+senza create exhibitor-appliance.yaml 1 saiki-exhibitor pierone.example.org/myteam/exhibitor:0.1-SNAPSHOT example.org. exhibitor-app example-stups-mint-some_id-eu-west-1 some_scalyr_key --region eu-west-1
+```
 
-Exhibitor provides [rest-api](https://github.com/Netflix/exhibitor/wiki/REST-Introduction) which could be accessd via: ```http://<STACK_VERSION>.exhibitor.<HOSTED_ZONE>/exhibitor/v1/```
+Cloudformation stack will start 3 EC2 instances in autoscaling group and create internal load balancer in front of EC2 instances. Also it will create DNS record ```"<STACK_NAME>-<STACK_VERSION>.<HOSTED_ZONE>"``` which points to a load balancer.
+
+Exhibitor provides [rest-api](https://github.com/Netflix/exhibitor/wiki/REST-Introduction) which could be accessd via: ```http://<STACK_NAME>-<STACK_VERSION>.<HOSTED_ZONE>/exhibitor/v1/```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ docker build -t <tag> .
 
 ###### Create S3 bucket
 ```
-S3_BUCKET="exhibitor-app"
+S3_BUCKET="exhibitor-bucket"
 aws s3 mb s3://$S3_BUCKET
 ```
 
@@ -25,7 +25,7 @@ senza create exhibitor-appliance.yaml <STACK_VERSION> <APPLICATION_ID> <DOCKER_I
 
 A real world example would be:
 ```
-senza create exhibitor-appliance.yaml 1 saiki-exhibitor pierone.example.org/myteam/exhibitor:0.1-SNAPSHOT example.org. exhibitor-app example-stups-mint-some_id-eu-west-1 some_scalyr_key --region eu-west-1
+senza create exhibitor-appliance.yaml 1 saiki-exhibitor pierone.example.org/myteam/exhibitor:0.1-SNAPSHOT example.org. exhibitor-bucket example-stups-mint-some_id-eu-west-1 some_scalyr_key --region eu-west-1
 ```
 
 Cloudformation stack will start 3 EC2 instances in autoscaling group and create internal load balancer in front of EC2 instances. Also it will create DNS record ```"<STACK_NAME>-<STACK_VERSION>.<HOSTED_ZONE>"``` which points to a load balancer.

--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -71,6 +71,15 @@ Resources:
       - InstancePort: 8181
         LoadBalancerPort: 80
         Protocol: TCP
+      - InstancePort: 2181
+        LoadBalancerPort: 2181
+        Protocol: TCP
+      - InstancePort: 2888
+        LoadBalancerPort: 2888
+        Protocol: TCP
+      - InstancePort: 3888
+        LoadBalancerPort: 3888
+        Protocol: TCP
       SecurityGroups:
       - "Fn::GetAtt" : [ "ExhibitorSecGroup" , "GroupId" ]
       Scheme: internet-facing

--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -36,7 +36,7 @@ SenzaComponents:
       root: True
       environment:
         S3_BUCKET: "{{Arguments.ExhibitorBucket}}"
-        S3_PREFIX: "{{Arguments.version}}"
+        S3_PREFIX: "{{SenzaInfo.StackName}}-{{Arguments.version}}"
       mint_bucket: "{{Arguments.MintBucket}}"
       scalyr_account_key: "{{Arguments.ScalyrAccountKey}}"
     Type: Senza::TaupageAutoScalingGroup

--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -74,12 +74,6 @@ Resources:
       - InstancePort: 2181
         LoadBalancerPort: 2181
         Protocol: TCP
-      - InstancePort: 2888
-        LoadBalancerPort: 2888
-        Protocol: TCP
-      - InstancePort: 3888
-        LoadBalancerPort: 3888
-        Protocol: TCP
       SecurityGroups:
       - "Fn::GetAtt" : [ "ExhibitorSecGroup" , "GroupId" ]
       Scheme: internet-facing

--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -1,3 +1,18 @@
+SenzaInfo:
+  StackName: acid-exhibitor
+  Parameters:
+    - ApplicationID:
+        Description: "The Application Id which got registered for exhibitor in Yourturn/Kio."
+    - DockerImage:
+        Description: "Docker image of exhibitor."
+    - HostedZone:
+        Description: "AWS Hosted Zone to work with."
+    - ExhibitorBucket:
+        Description: "S3 bucket for exhibitor (to store shared configuration and backups)."
+    - MintBucket:
+        Description: "The mint S3 bucket for OAuth 2.0 credentials."
+    - ScalyrAccountKey:
+        Description: "scalyr account key."
 SenzaComponents:
 - Configuration:
     Type: Senza::StupsAutoConfiguration
@@ -8,18 +23,19 @@ SenzaComponents:
     ElasticLoadBalancer: ExhibitorLoadBalancer
     HealthCheckType: ELB
     SecurityGroups:
-      - "{{Arguments.SecurityGroup}}"
+      - "Fn::GetAtt" : [ "ExhibitorSecGroup" , "GroupId" ]
     TaupageConfig:
+      application_id: "{{Arguments.ApplicationID}}"
+      runtime: Docker
+      source: "{{Arguments.DockerImage}}"
       ports:
         2181: 2181
         2888: 2888
         3888: 3888
         8181: 8181
-      runtime: Docker
-      source: "{{Arguments.DockerImage}}"
       root: True
       environment:
-        S3_BUCKET: "acid-exhibitor-app"
+        S3_BUCKET: "{{Arguments.ExhibitorBucket}}"
         S3_PREFIX: "{{Arguments.version}}"
       mint_bucket: "{{Arguments.MintBucket}}"
       scalyr_account_key: "{{Arguments.ScalyrAccountKey}}"
@@ -28,21 +44,6 @@ SenzaComponents:
         Minimum: 3
         Maximum: 3
         MetricType: CPU
-SenzaInfo:
-  StackName: acid-exhibitor
-  Parameters:
-  - DockerImage:
-      Description: Docker image of exhibitor
-  - SecurityGroup:
-      Description: Security group ID
-  - HostedZone:
-      Description: AWS Hosted Zone to work with
-  - ExhibitorBucket:
-      Description: S3 bucket for exhibitor (to store shared configuration and backups)
-  - MintBucket:
-      Description: The mint S3 bucket for OAuth 2.0 credentials
-  - ScalyrAccountKey:
-      Description: scalyr account key
 Resources:
   ExhibitorRoute53Record:
     Type: AWS::Route53::RecordSet
@@ -50,7 +51,7 @@ Resources:
       Type: CNAME
       TTL: 20
       HostedZoneName: "{{Arguments.HostedZone}}"
-      Name: "{{Arguments.version}}.exhibitor.{{Arguments.HostedZone}}"
+      Name: "{{SenzaInfo.StackName}}-{{Arguments.version}}.{{Arguments.HostedZone}}"
       ResourceRecords:
       - Fn::GetAtt:
         - ExhibitorLoadBalancer
@@ -58,6 +59,7 @@ Resources:
   ExhibitorLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
+      LoadBalancerName: "{{SenzaInfo.StackName}}-{{Arguments.version}}"
       CrossZone: true
       HealthCheck:
         HealthyThreshold: 3
@@ -69,10 +71,9 @@ Resources:
       - InstancePort: 8181
         LoadBalancerPort: 80
         Protocol: TCP
-      LoadBalancerName: "exhibitor-{{Arguments.version}}"
       SecurityGroups:
-      - "{{Arguments.SecurityGroup}}"
-      Scheme: internal
+      - "Fn::GetAtt" : [ "ExhibitorSecGroup" , "GroupId" ]
+      Scheme: internet-facing
       Subnets:
         Fn::FindInMap:
         - LoadBalancerSubnets
@@ -101,4 +102,33 @@ Resources:
             - "arn:aws:s3:::{{Arguments.ExhibitorBucket}}/*"
           - Effect: Allow
             Action: "s3:GetObject"
-            Resource: ["arn:aws:s3:::{{Arguments.MintBucket}}/*"]
+            Resource: ["arn:aws:s3:::{{Arguments.MintBucket}}/{{Arguments.ApplicationID}}/*"]
+  ExhibitorSecGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Exhibitor Appliance Security Group"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 2181
+          ToPort: 2181
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: tcp
+          FromPort: 2888
+          ToPort: 2888
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: tcp
+          FromPort: 3888
+          ToPort: 3888
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: tcp
+          FromPort: 8181
+          ToPort: 8181
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: "0.0.0.0/0"


### PR DESCRIPTION
1) security group can be defined in senza YAML file, this depends on the new feature since senza 0.62 (already released) https://github.com/zalando-stups/senza/pull/64

2) StackName as a variable should be a part of DNS name and S3_PREFIX, so that one team can create different exhibitor stacks with different StackName and the same stack version tag.

3) ApplicationID should be a variable, because in YourTurn ApplicationID must be unique defined. So we must use different ApplicationID for STUPS Appliance, but we can use same StackName for CloudFormation (acid-exhibitor).

4) Zookeeper ports are added in load balancer, so that we can use an unified domain name (stack's Route53 CNAME record) to access the Zookeeper Cluster under Exhibitor, we do not need to take care if the zookeeper nodes under Exhibitor are changed.
