### PR TITLE
Updated Senza configuration to create DNS entries which look similar to the default STUPS entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ A real world example would be:
 senza create exhibitor-appliance.yaml postgres acid-exhibitor pierone.example.org/myteam/exhibitor:0.1-SNAPSHOT example.org. exhibitor-bucket example-stups-mint-some_id-eu-west-1 some_scalyr_key --region eu-west-1
 ```
 
-Cloudformation stack will start 3 EC2 instances in autoscaling group and create internal load balancer in front of EC2 instances. Also it will create DNS record ```"<STACK_VERSION>.exhibitor.<HOSTED_ZONE>"``` which points to a load balancer.
+Cloudformation stack will start 3 EC2 instances in autoscaling group and create internal load balancer in front of EC2 instances. Also it will create DNS record ```"<APPLICATION_ID>-<STACK_VERSION>.<HOSTED_ZONE>"``` which points to a load balancer.
 
-Exhibitor provides [rest-api](https://github.com/Netflix/exhibitor/wiki/REST-Introduction) which could be accessd via: ```http://<STACK_VERSION>.exhibitor.<HOSTED_ZONE>/exhibitor/v1/```
+Exhibitor provides [rest-api](https://github.com/Netflix/exhibitor/wiki/REST-Introduction) which could be accessd via: ```http://<APPLICATION_ID>-<STACK_VERSION>.<HOSTED_ZONE>/exhibitor/v1/```

--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -1,5 +1,5 @@
 SenzaInfo:
-  StackName: acid-exhibitor
+  StackName: exhibitor
   Parameters:
     - ApplicationID:
         Description: The Application Id which got registered for exhibitor in Yourturn/Kio.
@@ -53,7 +53,7 @@ Resources:
       Type: CNAME
       TTL: 20
       HostedZoneName: "{{Arguments.HostedZone}}"
-      Name: "{{Arguments.version}}.exhibitor.{{Arguments.HostedZone}}"
+      Name: "{{Arguments.ApplicationID}}-{{Arguments.version}}.{{Arguments.HostedZone}}"
       ResourceRecords:
         - Fn::GetAtt:
             - ExhibitorLoadBalancer


### PR DESCRIPTION
LB DNS entry will now be `<APPLICATION_ID>-<STACK_VERSION>.<HOSTED_ZONE>` instead of `<STACK_VERSION>.exhibitor.<HOSTED_ZONE>` which is similar to the default DNS entries created by Senza (STUPS).
