### PR TITLE
#4 Makes availability zones configurable on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Make sure that your got an unique ```APPLICATION_ID```
 
 ###### Deploy with Senza
 ```
-senza create exhibitor-appliance.yaml <STACK_VERSION> <APPLICATION_ID> <DOCKER_IMAGE_WITH_VERSION_TAG> <HOSTED_ZONE> $S3_BUCKET <MINT_BUCKET> <SCALYR_KEY> [--region AWS_REGION]
+senza create exhibitor-appliance.yaml <STACK_VERSION> <APPLICATION_ID> <DOCKER_IMAGE_WITH_VERSION_TAG> <HOSTED_ZONE> <AVAILABILITY_ZONES> $S3_BUCKET <MINT_BUCKET> <SCALYR_KEY> [--region AWS_REGION]
 ```
 
 A real world example would be:
 ```
-senza create exhibitor-appliance.yaml postgres acid-exhibitor pierone.example.org/myteam/exhibitor:0.1-SNAPSHOT example.org. exhibitor-bucket example-stups-mint-some_id-eu-west-1 some_scalyr_key --region eu-west-1
+senza create exhibitor-appliance.yaml postgres acid-exhibitor pierone.example.org/myteam/exhibitor:0.1-SNAPSHOT example.org. eu-west-1a,eu-west-1b,eu-west-1c exhibitor-bucket example-stups-mint-some_id-eu-west-1 some_scalyr_key --region eu-west-1
 ```
 
 Cloudformation stack will start 3 EC2 instances in autoscaling group and create internal load balancer in front of EC2 instances. Also it will create DNS record ```"<APPLICATION_ID>-<STACK_VERSION>.<HOSTED_ZONE>"``` which points to a load balancer.

--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -7,6 +7,8 @@ SenzaInfo:
         Description: Docker image of exhibitor
     - HostedZone:
         Description: AWS Hosted Zone to work with
+    - AvailabilityZones:
+        Description: AWS Availablity Zones to start instances in
     - ExhibitorBucket:
         Description: S3 bucket for exhibitor (to store shared configuration and backups)
     - MintBucket:
@@ -16,6 +18,8 @@ SenzaInfo:
 SenzaComponents:
   - Configuration:
       Type: Senza::StupsAutoConfiguration
+      AvailabilityZones: [eu-west-1a]
+
   - AppServer:
       IamRoles:
         - Ref: ExhibitorRole


### PR DESCRIPTION
This allows to configure the availability zones in which Zookeeper instances should be started. 

Background: It is recommended to run Zookeeper and e.g. Solr in the same AZ in order to have a low latency.
