### PR TITLE
make local execution possible

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,6 @@
 
 HOSTNAME=$(curl --connect-timeout 5 http://169.254.169.254/latest/meta-data/hostname || echo "localhost")
 AVAILABILITY_ZONE=$(curl --connect-timeout 5 http://169.254.169.254/latest/meta-data/placement/availability-zone || echo "")
-AWS_REGION=${AVAILABILITY_ZONE:0:${#AVAILABILITY_ZONE} - 1}
 
 # Generates the default exhibitor config and launches exhibitor
 cat /opt/exhibitor/exhibitor.conf.tmpl > exhibitor.conf
@@ -17,6 +16,7 @@ if [[ $AVAILABILITY_ZONE == '' ]]; then
     echo "local environment, starting without S3 backup"
     CONFIG_TYPE="file"
 else
+    AWS_REGION=${AVAILABILITY_ZONE:0:${#AVAILABILITY_ZONE} - 1}
     CONFIG_TYPE="s3  --s3config ${S3_BUCKET}:${S3_PREFIX} --s3region ${AWS_REGION} --s3backup true"
 fi 
 


### PR DESCRIPTION
currently the appliance needs to be running on AWS and have access to S3. For local development and execution it would be useful to have a locally running docker image. The improvement over the "normal" ZK images is the rest api and the webinterface.

this PR changes the startup script to use file based mode if no AWS information can be found.

for local execution it needs to run with the --net=host option of docker, since we're assigning localhost as hostname currently ...
