### PR TITLE
use hostname for local execution instead of localhost

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #/bin/bash -e
 
-HOSTNAME=$(curl --connect-timeout 5 http://169.254.169.254/latest/meta-data/hostname || echo "localhost")
+HOSTNAME=$(curl --connect-timeout 5 http://169.254.169.254/latest/meta-data/hostname || echo $(hostname))
 AVAILABILITY_ZONE=$(curl --connect-timeout 5 http://169.254.169.254/latest/meta-data/placement/availability-zone || echo "")
 
 # Generates the default exhibitor config and launches exhibitor


### PR DESCRIPTION
this enables full customizable servername which gets passed to zookeeper and therefor docker linking possibilities
