### PR TITLE
fix for invalid senza definition file structure

### DIFF
--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -46,7 +46,7 @@ SenzaComponents:
           3888: 3888
           8181: 8181
         root: True
-      environment:
+        environment:
           S3_BUCKET: "{{Arguments.ExhibitorBucket}}"
           S3_PREFIX: "{{Arguments.version}}"
           USE_HOSTNAME: "{{Arguments.UseHostName}}"


### PR DESCRIPTION
Commit 5305174d36f81500a926a88fdd9b666b24c1f914 removed spaces from the environment element making it an invalid YAML structure. This is the fix for the problem.
