### PR TITLE
aruha-738 parameterize data directories

### DIFF
--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -21,10 +21,10 @@ SenzaInfo:
         Default: ""
     - CustomTransactionsDirectory:
         Description: "Use custom transactions directory"
-        Default: "/opt/exhibitor/transactions"
+        Default: "/opt/zookeeper/transactions"
     - CustomSnapshotsDirectory:
         Description: "Use custom snapshots directory"
-        Default: "/opt/exhibitor/snapshots"
+        Default: "/opt/zookeeper/snapshots"
 SenzaComponents:
   - Configuration:
       Type: Senza::StupsAutoConfiguration

--- a/exhibitor-appliance.yaml
+++ b/exhibitor-appliance.yaml
@@ -19,6 +19,12 @@ SenzaInfo:
     - CustomS3BucketRegion:
         Description: "Use custom s3 bucket region for exhibitor configuration"
         Default: ""
+    - CustomTransactionsDirectory:
+        Description: "Use custom transactions directory"
+        Default: "/opt/exhibitor/transactions"
+    - CustomSnapshotsDirectory:
+        Description: "Use custom snapshots directory"
+        Default: "/opt/exhibitor/snapshots"
 SenzaComponents:
   - Configuration:
       Type: Senza::StupsAutoConfiguration
@@ -48,6 +54,8 @@ SenzaComponents:
           S3_PREFIX: "{{Arguments.version}}"
           USE_HOSTNAME: "{{Arguments.UseHostName}}"
           AWS_REGION: "{{Arguments.CustomS3BucketRegion}}"
+          TRANSACTIONS_DIR: "{{Arguments.CustomTransactionsDirectory}}"
+          SNAPSHOTS_DIR: "{{Arguments.CustomSnapshotsDirectory}}"
         appdynamics_application: '{{Arguments.ApplicationID}}-{{Arguments.version}}'
         application_logrotate_size: 100M
         application_logrotate_rotate: 4

--- a/exhibitor.conf.tmpl
+++ b/exhibitor.conf.tmpl
@@ -1,7 +1,4 @@
 zookeeper-install-directory=/opt/zookeeper
-zookeeper-data-directory=/opt/zookeeper/snapshots
-zookeeper-log-directory=/opt/zookeeper/transactions
-log-index-directory=/opt/zookeeper/transactions
 cleanup-period-ms=300000
 check-ms=30000
 backup-period-ms=600000


### PR DESCRIPTION
In order to leverage high performance IO disks from AWS i3 instance family,
it's necessary to mount a volume on a given path and later write data
files to this volume.

This commit exposes two environmnent variables that can be used to
specify the path to the mounted volume.