### PR TITLE
Fix snapshots directory

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ if [[ "x$TRANSACTIONS_DIR" == "x" ]]; then
 fi
 mkdir -m 777 -p ${TRANSACTIONS_DIR}
 if [[ "x$SNAPSHOTS_DIR" == "x" ]]; then
-   SNAPSHOTS_DIR="/opt/zookeeper/transactions"
+   SNAPSHOTS_DIR="/opt/zookeeper/snapshots"
 fi
 mkdir -m 777 -p ${SNAPSHOTS_DIR}
 


### PR DESCRIPTION
When testing the changes made in #31 I did not executed this path. It
introduces a serious bug for new stacks, which would cause snapshots to
be written in the same directory as transactions.

User deploying stacks from the sample senza file would not be affected, since it correctly specified defaults.